### PR TITLE
FEATURE: Allow version numbers in full namespace

### DIFF
--- a/Classes/Domain/Service/VersionResolver.php
+++ b/Classes/Domain/Service/VersionResolver.php
@@ -7,7 +7,17 @@ class VersionResolver
 {
     public function extractVersion(string $migrationClassName): string
     {
-        preg_match('#\\Version(\d+)$#', $migrationClassName, $matches);
-        return $matches[1];
+        /*
+         *  date format version number:
+         *       4 digits year
+         *    +  2 digits month
+         *    +  2 digits day
+         *    +  2 digits hour
+         *    +  2 digits minute
+         *    +  2 digits second
+         *    = 14 digits
+         */
+        preg_match('#\\\\Version(?<dateFormatVersionNumber>\\d{14})(\\\\|$)#', $migrationClassName, $matches);
+        return $matches['dateFormatVersionNumber'];
     }
 }


### PR DESCRIPTION
Migration classes are usually named like "Version20200911105700" to be
both, naturally sorted and with little chance to conflict.

This patch allows for migration classes with arbitrary names but
living in namespaces that contain the version number part.

This patch does not change how migratins are detected within the file
system.