### PR TITLE
BUGFIX: Fix unit tests

### DIFF
--- a/Classes/Domain/Service/VersionResolver.php
+++ b/Classes/Domain/Service/VersionResolver.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Netlogix\Migrations\Domain\Service;
 
+use Netlogix\Migrations\Error\InvalidClassName;
+
 class VersionResolver
 {
     public function extractVersion(string $migrationClassName): string
@@ -18,6 +20,12 @@ class VersionResolver
          *    = 14 digits
          */
         preg_match('#(\\\\|^)Version(?<dateFormatVersionNumber>\\d{14})(\\\\|$)#', $migrationClassName, $matches);
+        if (!isset($matches['dateFormatVersionNumber'])) {
+            throw new InvalidClassName(
+                'Version numbered class names are required to match "Version" followed by exactly 14 digits.',
+                1605102278
+            );
+        }
         return $matches['dateFormatVersionNumber'];
     }
 }

--- a/Classes/Domain/Service/VersionResolver.php
+++ b/Classes/Domain/Service/VersionResolver.php
@@ -17,7 +17,7 @@ class VersionResolver
          *    +  2 digits second
          *    = 14 digits
          */
-        preg_match('#\\\\Version(?<dateFormatVersionNumber>\\d{14})(\\\\|$)#', $migrationClassName, $matches);
+        preg_match('#(\\\\|^)Version(?<dateFormatVersionNumber>\\d{14})(\\\\|$)#', $migrationClassName, $matches);
         return $matches['dateFormatVersionNumber'];
     }
 }

--- a/Classes/Error/InvalidClassName.php
+++ b/Classes/Error/InvalidClassName.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\Migrations\Error;
+
+class InvalidClassName extends \InvalidArgumentException
+{
+}

--- a/Tests/Unit/Domain/Service/MigrationServiceTest.php
+++ b/Tests/Unit/Domain/Service/MigrationServiceTest.php
@@ -62,8 +62,8 @@ class MigrationServiceTest extends UnitTestCase
 
         $this->fileSystemMigrationsResolver->method('findMigrationFiles')
             ->willReturn([
-                Version1312192::class,
-                Version1312193::class,
+                Version20191001142901::class,
+                Version20191001142902::class,
             ]);
 
         $this->migrationService = new MigrationService(
@@ -107,7 +107,7 @@ class MigrationServiceTest extends UnitTestCase
             ->getMock();
 
         $migrationStatusMock->method('getVersion')
-            ->willReturn('1312192');
+            ->willReturn('20191001142901');
 
         $this->migrationStatusRepository->method('findAll')
             ->willReturn([$migrationStatusMock]);
@@ -115,7 +115,7 @@ class MigrationServiceTest extends UnitTestCase
         $migrations = $this->migrationService->findUnexecutedMigrations();
 
         $this->assertCount(1, $migrations);
-        $this->assertArrayHasKey('1312193', $migrations);
+        $this->assertArrayHasKey('20191001142902', $migrations);
     }
 
     /**
@@ -134,12 +134,12 @@ class MigrationServiceTest extends UnitTestCase
             ->getMock();
 
         $migrationStatusMock->method('getVersion')
-            ->willReturn('1312192');
+            ->willReturn('20191001142901');
 
         $this->migrationStatusRepository->method('findAll')
             ->willReturn([$migrationStatusMock]);
 
-        $migration = $this->migrationService->getMigrationByVersion('1312192');
+        $migration = $this->migrationService->getMigrationByVersion('20191001142901');
 
         $this->assertInstanceOf(Migration::class, $migration);
     }
@@ -162,7 +162,7 @@ class MigrationServiceTest extends UnitTestCase
             ->getMock();
 
         $migrationStatusMock->method('getVersion')
-            ->willReturn('1312192');
+            ->willReturn('20191001142901');
 
         $this->migrationStatusRepository->method('findAll')
             ->willReturn([$migrationStatusMock]);
@@ -171,10 +171,10 @@ class MigrationServiceTest extends UnitTestCase
     }
 }
 
-class Version1312192 {
+class Version20191001142901 {
 
 }
 
-class Version1312193 {
+class Version20191001142902 {
 
 }

--- a/Tests/Unit/Domain/Service/VersionResolverTest.php
+++ b/Tests/Unit/Domain/Service/VersionResolverTest.php
@@ -3,12 +3,9 @@ declare(strict_types=1);
 
 namespace Netlogix\Migrations\Tests\Unit\Domain\Service;
 
-use Doctrine\DBAL\Migrations\Finder\GlobFinder;
-use Neos\Flow\Package;
-use Neos\Flow\Package\PackageManager;
 use Neos\Flow\Tests\UnitTestCase;
-use Netlogix\Migrations\Domain\Model\Migration;
 use Netlogix\Migrations\Domain\Service\VersionResolver;
+use Netlogix\Migrations\Error\InvalidClassName;
 
 class VersionResolverTest extends UnitTestCase
 {
@@ -20,26 +17,44 @@ class VersionResolverTest extends UnitTestCase
     protected function setUp()
     {
         parent::setUp();
-
-       $this->versionResolver = new VersionResolver();
+        $this->versionResolver = new VersionResolver();
     }
 
     /**
      * @test
-     * @dataProvider getProvidedData
+     * @dataProvider validClassNames
      */
     public function Can_extract_version_string(string $migrationClassName, string $expectedVersionString)
     {
         $this->assertEquals($expectedVersionString, $this->versionResolver->extractVersion($migrationClassName));
     }
 
-    public function getProvidedData()
+    /**
+     * @test
+     * @dataProvider invalidClassNames
+     */
+    public function Can_not_extract_version_string(string $migrationClassName)
+    {
+        $this->expectException(InvalidClassName::class);
+        $this->versionResolver->extractVersion($migrationClassName);
+    }
+
+    public function invalidClassNames()
     {
         return [
-            ['Version20190930132259', '20190930132259'],
+            'lower case class name' => ['version20201111145100'],
+            'to many digits' => ['Version202011111451001'],
+            'to little digits' => ['version2020111114510'],
+        ];
+    }
+
+    public function validClassNames()
+    {
+        return [
+            'class name without namespace' => ['Version20190930132259', '20190930132259'],
             ['Version20190930132253', '20190930132253'],
-            ['Migrations\\Version20201111143501', '20201111143501'],
-            ['Migrations\\Version20201111143502\\MyClass', '20201111143502'],
+            'class name with namespace' => ['Migrations\\Version20201111143501', '20201111143501'],
+            'version number in namespace' => ['Migrations\\Version20201111143502\\MyClass', '20201111143502'],
         ];
     }
 }

--- a/Tests/Unit/Domain/Service/VersionResolverTest.php
+++ b/Tests/Unit/Domain/Service/VersionResolverTest.php
@@ -38,6 +38,8 @@ class VersionResolverTest extends UnitTestCase
         return [
             ['Version20190930132259', '20190930132259'],
             ['Version20190930132253', '20190930132253'],
+            ['Migrations\\Version20201111143501', '20201111143501'],
+            ['Migrations\\Version20201111143502\\MyClass', '20201111143502'],
         ];
     }
 }


### PR DESCRIPTION
Version numbered migration class names are required to contain a 14
digits version number. Test cases came with ony 6 digits.