### PR TITLE
BUGFIX: Add missing type hints to tests

### DIFF
--- a/Tests/Unit/Domain/Service/FileSystemMigrationsResolverTest.php
+++ b/Tests/Unit/Domain/Service/FileSystemMigrationsResolverTest.php
@@ -15,7 +15,7 @@ class FileSystemMigrationsResolverTest extends UnitTestCase
      */
     private $fileSystemMigrationsResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -42,7 +42,7 @@ class FileSystemMigrationsResolverTest extends UnitTestCase
     /**
      * @test
      */
-    public function Can_return_empty_array()
+    public function Can_return_empty_array(): void
     {
         $files = $this->fileSystemMigrationsResolver->findMigrationFiles();
         $this->assertCount(0, $files);

--- a/Tests/Unit/Domain/Service/MigrationExecutorTest.php
+++ b/Tests/Unit/Domain/Service/MigrationExecutorTest.php
@@ -34,7 +34,7 @@ class MigrationExecutorTest extends UnitTestCase
      */
     private $objectManager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -60,7 +60,7 @@ class MigrationExecutorTest extends UnitTestCase
     /**
      * @test
      */
-    public function It_Will_Throw_Missing_Migration_Handler()
+    public function It_Will_Throw_Missing_Migration_Handler(): void
     {
         $this->expectException(MissingMigrationHandler::class);
 
@@ -75,7 +75,7 @@ class MigrationExecutorTest extends UnitTestCase
     /**
      * @test
      */
-    public function It_Will_Execute_Migration_Handler()
+    public function It_Will_Execute_Migration_Handler(): void
     {
         $migration = $this->createMock(Migration::class);
 

--- a/Tests/Unit/Domain/Service/MigrationServiceTest.php
+++ b/Tests/Unit/Domain/Service/MigrationServiceTest.php
@@ -40,7 +40,7 @@ class MigrationServiceTest extends UnitTestCase
      */
     private $migrationStatusRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -77,7 +77,7 @@ class MigrationServiceTest extends UnitTestCase
     /**
      * @test
      */
-    public function Can_Return_UnexecutedMigrations()
+    public function Can_Return_UnexecutedMigrations(): void
     {
         $migrationMock = $this->getMockBuilder(Migration::class)
             ->getMock();
@@ -94,7 +94,7 @@ class MigrationServiceTest extends UnitTestCase
     /**
      * @test
      */
-    public function Can_Filter_Executed_Migrations_In_Get_UnexecutedMigrations()
+    public function Can_Filter_Executed_Migrations_In_Get_UnexecutedMigrations(): void
     {
         $migrationMock = $this->getMockBuilder(Migration::class)
             ->getMock();
@@ -121,7 +121,7 @@ class MigrationServiceTest extends UnitTestCase
     /**
      * @test
      */
-    public function Can_Return_A_Single_Migration()
+    public function Can_Return_A_Single_Migration(): void
     {
         $migrationMock = $this->getMockBuilder(Migration::class)
             ->getMock();
@@ -147,7 +147,7 @@ class MigrationServiceTest extends UnitTestCase
     /**
      * @test
      */
-    public function Will_Throw_Unknown_Migration_If_Migration_Not_Found()
+    public function Will_Throw_Unknown_Migration_If_Migration_Not_Found(): void
     {
         $this->expectException(UnknownMigration::class);
 

--- a/Tests/Unit/Domain/Service/VersionLoggerTest.php
+++ b/Tests/Unit/Domain/Service/VersionLoggerTest.php
@@ -23,7 +23,7 @@ class VersionLoggerTest extends UnitTestCase
      */
     private $migrationStatusRepository;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -53,7 +53,7 @@ class VersionLoggerTest extends UnitTestCase
     /**
      * @test
      */
-    public function Can_Store_New_MigrationStatus_On_Up()
+    public function Can_Store_New_MigrationStatus_On_Up(): void
     {
         $migration = $this->createMock(Migration::class);
 
@@ -66,7 +66,7 @@ class VersionLoggerTest extends UnitTestCase
     /**
      * @test
      */
-    public function Can_Remove_MigrationStatus_On_Down()
+    public function Can_Remove_MigrationStatus_On_Down(): void
     {
         $migration = $this->createMock(Migration::class);
 

--- a/Tests/Unit/Domain/Service/VersionResolverTest.php
+++ b/Tests/Unit/Domain/Service/VersionResolverTest.php
@@ -14,7 +14,7 @@ class VersionResolverTest extends UnitTestCase
      */
     private $versionResolver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->versionResolver = new VersionResolver();
@@ -24,7 +24,7 @@ class VersionResolverTest extends UnitTestCase
      * @test
      * @dataProvider validClassNames
      */
-    public function Can_extract_version_string(string $migrationClassName, string $expectedVersionString)
+    public function Can_extract_version_string(string $migrationClassName, string $expectedVersionString): void
     {
         $this->assertEquals($expectedVersionString, $this->versionResolver->extractVersion($migrationClassName));
     }
@@ -33,13 +33,13 @@ class VersionResolverTest extends UnitTestCase
      * @test
      * @dataProvider invalidClassNames
      */
-    public function Can_not_extract_version_string(string $migrationClassName)
+    public function Can_not_extract_version_string(string $migrationClassName): void
     {
         $this->expectException(InvalidClassName::class);
         $this->versionResolver->extractVersion($migrationClassName);
     }
 
-    public function invalidClassNames()
+    public function invalidClassNames(): array
     {
         return [
             'lower case class name' => ['version20201111145100'],
@@ -48,7 +48,7 @@ class VersionResolverTest extends UnitTestCase
         ];
     }
 
-    public function validClassNames()
+    public function validClassNames(): array
     {
         return [
             'class name without namespace' => ['Version20190930132259', '20190930132259'],


### PR DESCRIPTION
Tests on Flow 6.3 are broken without the type hints